### PR TITLE
Clarifying description of the Capacity property in the Array class

### DIFF
--- a/docs/lib/Array.htm
+++ b/docs/lib/Array.htm
@@ -54,7 +54,7 @@ MsgBox users[1]</pre>
   <li><a href="#Properties">Properties</a>:
     <ul>
       <li><a href="#Length">Length</a>: Gets or sets the length of an array.</li>
-      <li><a href="#Capacity">Capacity</a>: Gets or sets the current capacity of an array.</li>
+      <li><a href="#Capacity">Capacity</a>: Gets or sets the current allocated memory capacity of an array.</li>
       <li><a href="#Default">Default</a>: Sets the default value returned when an element with no value is requested.</li>
       <li><a href="#__Item">__Item</a>: Gets or sets the value of an array element.</li>
     </ul>
@@ -245,7 +245,7 @@ MsgBox ["A",    , "C"].Length  <em>;  3</em>
 </div>
 
 <div class="methodShort" id="Capacity"><h3>Capacity</h3>
-<p>Gets or sets the current capacity of an array.</p>
+<p>Gets or sets the current allocated memory capacity of an array.</p>
 <pre class="Syntax">MaxItems := ArrayObj.<span class="func">Capacity</span></pre>
 <pre class="Syntax">ArrayObj.<span class="func">Capacity</span> := MaxItems</pre>
 <p><em>MaxItems</em> is an <a href="../Concepts.htm#numbers">integer</a> representing the maximum number of elements the array should be able to contain before it must be automatically expanded.  If setting a value less than <a href="#Length">Length</a>, elements are removed.</p>


### PR DESCRIPTION
Clarifies that the `Capacity` property in the Array class affects the current *allocated memory* capacity of the array. As is, the documentation does not clearly distinguish the difference between the `Length` and the `Capacity` properties. Some users are confusing the two. For example, see [this post](https://www.autohotkey.com/boards/viewtopic.php?f=82&t=141026).

The following code snippet distinguishes the two:

```
arr := [10, 20, 30]
MsgBox arr.Length    ; 3 — three elements
MsgBox arr.Capacity  ; 3 or more — depends on internal allocation

arr.Capacity := 100  ; pre-allocate for 100 elements (no reallocation needed as you push)
arr.Push(40)
MsgBox arr.Length    ; 4
MsgBox arr.Capacity  ; still 100